### PR TITLE
Sebastian/backup xdmf files

### DIFF
--- a/backends/Base.h
+++ b/backends/Base.h
@@ -310,16 +310,17 @@ protected:
 	/**
 	 * Backup an existing backend file
 	 */
-	void backup(const std::string &file)
+	void backup(std::string const& prefix, std::string const& fileExention)
 	{
+                std::string fileName = prefix + fileExention;
 		// Backup any existing file
 		struct stat statBuffer;
-		if (m_rank == 0 && stat(file.c_str(), &statBuffer) == 0) {
-			logWarning() << file << "already exists. Creating backup.";
+		if (m_rank == 0 && stat(fileName.c_str(), &statBuffer) == 0) {
+			logWarning() << fileName << "already exists. Creating backup.";
 			if (!m_backupTimeStamp.has_value()) {
 				m_backupTimeStamp = utils::TimeUtils::timeAsString("%F_%T", time(0L));
 			}
-			rename(file.c_str(), (file + ".bak_" + m_backupTimeStamp.value()).c_str());
+			rename(fileName.c_str(), (prefix + ".bak_" + m_backupTimeStamp.value() + fileExention).c_str());
 		}
 	}
 

--- a/backends/Base.h
+++ b/backends/Base.h
@@ -318,7 +318,7 @@ protected:
 		if (m_rank == 0 && stat(fileName.c_str(), &statBuffer) == 0) {
 			logWarning() << fileName << "already exists. Creating backup.";
 			if (!m_backupTimeStamp.has_value()) {
-				m_backupTimeStamp = utils::TimeUtils::timeAsString("%F_%T", time(0L));
+				m_backupTimeStamp = utils::TimeUtils::timeAsString("%Y-%m-%d_%H-%M-%S", time(0L));
 			}
 			rename(fileName.c_str(), (prefix + ".bak_" + m_backupTimeStamp.value() + fileExention).c_str());
 		}

--- a/backends/HDF5.h
+++ b/backends/HDF5.h
@@ -96,7 +96,7 @@ public:
 		// Create a backup of the file
 		if (create) {
 			// Backup existing file
-			Base<T>::backup(outputPrefix + fileExention());
+			Base<T>::backup(outputPrefix, fileExention());
 #ifdef PARALLEL
 			// Make sure the file is moved before continuing
 			MPI_Barrier(Base<T>::comm());

--- a/backends/Posix.h
+++ b/backends/Posix.h
@@ -72,7 +72,7 @@ public:
 
 		if (create) {
 			if (Base<T>::rank() == 0) {
-				Base<T>::backup(outputPrefix);
+				Base<T>::backup(outputPrefix, "");
 				checkErr(mkdir(outputPrefix.c_str(), 0755));
 			}
 


### PR DESCRIPTION
Also backup xdmf files.
Note `:` in the filename is not a good idea, since paraview interprets the `:` as delimiter between filename and hdf5 path in the file.
